### PR TITLE
[Doppins] Upgrade dependency proselint to ==0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 yamllint==1.3.2
-proselint==0.6.1
+proselint==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 yamllint==1.3.2
-proselint==0.6.0
+proselint==0.6.1


### PR DESCRIPTION
Hi!

A new version was just released of `proselint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded proselint from `==0.6.0` to `==0.6.1`

#### Changelog:

#### Version 0.6.1
+ Improve handling when there are invalid UTF-8 characters
+ Sort CLI output by line and column

