### PR TITLE
Add more links to the tools in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ For our own project linting, we use the `latest` version of the image (so we can
 - [yamllint](https://github.com/adrienverge/yamllint)
 - [bootlint](https://github.com/twbs/bootlint)
 - [coffeelint](https://github.com/clutchski/coffeelint)
-- csslint
-- dependency-lint
-- dockerfile_lint
-- doiuse
-- eslint + plugins
-- jscs
+- [csslint](https://github.com/CSSLint/csslint)
+- [dependency-lint](https://github.com/charlierudolph/dependency-lint)
+- [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint)
+- [doiuse](https://github.com/anandthakker/doiuse)
+- [eslint](https://github.com/eslint/eslint) + plugins
+- [jscs](https://github.com/jscs-dev/node-jscs)
 - jshint
 - jslint
 - markdownlint

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ For our own project linting, we use the `latest` version of the image (so we can
 - [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint)
 - [doiuse](https://github.com/anandthakker/doiuse)
 - [eslint](https://github.com/eslint/eslint) + plugins
-- [jscs](https://github.com/jscs-dev/node-jscs)
 - jshint
 - jslint
 - markdownlint


### PR DESCRIPTION
BTW When I got into `jscs` - do you really have this tool onboard ? grep shows only this

```
$ grep -R jscs .
Binary file ./.git/index matches
./README.md:- [jscs](https://github.com/jscs-dev/node-jscs)
./README.md:✔ jscs
```
